### PR TITLE
Add family-specific script paths

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,4 +31,8 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build & Push image
-        run: scripts/build_image_ci.sh $(yq .run_name params.yaml)
+        run: |
+          scripts/build_image_ci.sh \
+            $(yq .family params.yaml) \
+            $(yq .run_name params.yaml) \
+            $(yq .ci.quant_mode params.yaml)

--- a/Dockerfile.serve
+++ b/Dockerfile.serve
@@ -1,0 +1,8 @@
+FROM ollama/ollama:latest
+
+COPY model.gguf /model/model.gguf
+COPY Modelfile /workspace/Modelfile
+
+RUN ollama create model /workspace/Modelfile && rm /workspace/Modelfile
+
+CMD ["ollama", "serve"]

--- a/Modelfile.template
+++ b/Modelfile.template
@@ -1,0 +1,2 @@
+FROM llama2
+ADAPTER /model/model.gguf

--- a/README.md
+++ b/README.md
@@ -52,6 +52,35 @@ pip install -r requirements.txt
 
 ---
 
+
+## 📁 Model Directory Layout
+
+Artifacts are organised by **family** so teams can train and roll back versions independently.
+
+```
+models/
+  hf/
+    wip/<family>/<timestamp>-<run_name>/      # raw training outputs
+    candidates/<family>/<run_name>_merged/    # merged checkpoints
+    stable/<family>/<version>.dvc             # pointer to active stable run
+  gguf/<family>/                              # converted/quantised weights
+  modelfiles/<family>/<run_name>.Modelfile    # Ollama configs
+```
+
+Set `family` and `run_name` in `params.yaml` before each run.
+
+## 🔄 Pipeline Workflow
+
+1. **Train** – run `python -m model_lab.train` or `Scripts/run_train.ps1`.
+   Outputs go to `models/hf/wip/<family>/<timestamp>-<run_name>`.
+2. **Promote** – call `Scripts/promote.ps1 '<timestamp>-<run_name>'` to copy the
+   run to `models/hf/candidates/<family>` and commit the DVC pointer.
+3. **Reproduce** – execute `dvc repro` to merge adapters, convert to GGUF,
+   optionally quantise, generate a Modelfile and build the Docker image.
+4. **Serve & Test** – load the image in Ollama and run `src/ui/app.py` for A/B
+   testing. After 24 h, mark the winner stable by updating the pointer under
+   `models/hf/stable/<family>`. Previous stables remain for rollbacks.
+
 ## 🖥 Usage
 
 Edit the configuration section at the top of `Finetuned_qwen.ipynb`:

--- a/Scripts/build_image_ci.sh
+++ b/Scripts/build_image_ci.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
-RUN=$1
-IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}/model-lab:${RUN}"
 
-docker build --build-arg GGUF=models/gguf/${RUN}_full.gguf \
-             -f Dockerfile.serve \
-             -t $IMAGE .
-docker push $IMAGE
-echo $IMAGE > .ci/image_${RUN}.txt
+FAMILY=$1
+RUN=$2
+MODE=${3:-q4_k_m}
+IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}/model-lab:${FAMILY}_${RUN}"
+
+GGUF="models/gguf/${FAMILY}/${RUN}_${MODE}.gguf"
+if [[ ! -f "$GGUF" ]]; then
+  GGUF="models/gguf/${FAMILY}/${RUN}_full.gguf"
+fi
+
+CTX=".ci/build_${FAMILY}_${RUN}"
+mkdir -p "$CTX"
+cp "$GGUF" "$CTX/model.gguf"
+cp "models/modelfiles/${FAMILY}/${RUN}.Modelfile" "$CTX/Modelfile"
+
+docker build -f Dockerfile.serve -t "$IMAGE" "$CTX"
+docker push "$IMAGE"
+echo "$IMAGE" > ".ci/image_${FAMILY}_${RUN}.txt"

--- a/Scripts/promote.ps1
+++ b/Scripts/promote.ps1
@@ -30,17 +30,18 @@ $repo = Split-Path $PSScriptRoot -Parent
 Set-Location $repo
 
 Import-Module powershell-yaml -ErrorAction Stop
-$params = ConvertFrom-Yaml (Get-Content params.yaml -Raw)
+$params  = ConvertFrom-Yaml (Get-Content params.yaml -Raw)
 $runName = $params.run_name
+$family  = $params.family
 
 if (-not $WipFolder.EndsWith($runName)) {
   throw "WIP folder '$WipFolder' does not match run_name '$runName'"
 }
-$candDir = "models/hf/candidates/$runName"
+$candDir = "models/hf/candidates/$family/$runName"
 if (Test-Path $candDir) { throw "Candidate '$runName' already exists" }
 
 # 1) copy wip → candidates
-Copy-Item "models/hf/wip/$WipFolder" $candDir -Recurse
+Copy-Item "models/hf/wip/$family/$WipFolder" $candDir -Recurse
 
 # 2) ask quantization
 $answer = Read-Host "Quantize GGUF to Q4_0? (y/n)"

--- a/Scripts/run_temp_eval.ps1
+++ b/Scripts/run_temp_eval.ps1
@@ -17,7 +17,8 @@ $env:PYTHONPATH = Join-Path $projectRoot 'src'
 # 3) load params and compute paths
 $p = ConvertFrom-Yaml (Get-Content 'params.yaml' -Raw)
 $run   = $p.run_name
-$wip   = "$($p.output_root)/$run"
+$fam   = $p.family
+$wip   = "$($p.output_root)/$fam/$run"
 
 # 4) run eval
 Write-Host "`n Evaluating run: $run"

--- a/Scripts/run_train.ps1
+++ b/Scripts/run_train.ps1
@@ -22,7 +22,8 @@ $params = ConvertFrom-Yaml (Get-Content 'params.yaml' -Raw)
 
 # ─── 4) Compute the WIP folder path ──────────────────────────────────────────────
 $stamp = Get-Date -Format 'yyyy-MM-ddTHH-mm'
-$wip   = "$($params.output_root)/$stamp-$($params.run_name)"
+$fam   = $params.family
+$wip   = "$($params.output_root)/$fam/$stamp-$($params.run_name)"
 
 # ▶ Add this:
 $env:PYTHONPATH = Join-Path $projectRoot 'src'

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,5 +1,5 @@
 vars:
-  - params.yaml          # makes ${run_name}, ${base_model.repo}, …
+  - params.yaml          # makes ${run_name}, ${base_model.repo}, ${family}, …
 
 stages:
 # ─────────────────────────────────────────────── merge
@@ -7,58 +7,69 @@ stages:
     cmd: >
       python -m model_lab.merge_adapters
       --base     "${base_model.repo}"
-      --adapter  models/hf/wip/${run_name}
-      --out      models/hf/candidates/${run_name}_merged
+      --adapter  models/hf/wip/${family}/${run_name}
+      --out      models/hf/candidates/${family}/${run_name}_merged
     deps:
       - src/model_lab/merge_adapters.py
-      - models/hf/wip/${run_name}
+      - models/hf/wip/${family}/${run_name}
     outs:
-      - models/hf/candidates/${run_name}_merged
+      - models/hf/candidates/${family}/${run_name}_merged
 
 # ─────────────────────────────────────────────── gguf
   gguf:
     cmd: >
-      python -m model_lab.tools.convert_to_gguf models/hf/candidates/${run_name}_merged --out_file models/gguf/${run_name}_full.gguf
+      python -m model_lab.tools.convert_to_gguf models/hf/candidates/${family}/${run_name}_merged --out_file models/gguf/${family}/${run_name}_full.gguf
     deps:
       - src/model_lab/tools/convert_to_gguf.py
-      - models/hf/candidates/${run_name}_merged
+      - models/hf/candidates/${family}/${run_name}_merged
     outs:
-      - models/gguf/${run_name}_full.gguf
+      - models/gguf/${family}/${run_name}_full.gguf
 
 # ─────────────────────────────────────────────── quant
   quant:
     cmd: >
-      python -m model_lab.tools.quantize_gguf  models/gguf/${run_name}_full.gguf models/gguf/${run_name}_${ci.quant_mode}.gguf ${ci.quant_mode}
+      python -m model_lab.tools.quantize_gguf  models/gguf/${family}/${run_name}_full.gguf models/gguf/${family}/${run_name}_${ci.quant_mode}.gguf ${ci.quant_mode}
     deps:
       - src/model_lab/tools/quantize_gguf.py
-      - models/gguf/${run_name}_full.gguf
+      - models/gguf/${family}/${run_name}_full.gguf
     outs:
-      - models/gguf/${run_name}_${ci.quant_mode}.gguf
+      - models/gguf/${family}/${run_name}_${ci.quant_mode}.gguf
+
+# ─────────────────────────────────────────────── modelfile
+  modelfile:
+    cmd: >
+      python -m model_lab.tools.generate_modelfile models/gguf/${family}/${run_name}_${ci.quant_mode}.gguf --base ${base_model.repo} --out models/modelfiles/${family}/${run_name}.Modelfile
+    deps:
+      - src/model_lab/tools/generate_modelfile.py
+      - Modelfile.template
+      - models/gguf/${family}/${run_name}_${ci.quant_mode}.gguf
+    outs:
+      - models/modelfiles/${family}/${run_name}.Modelfile
 
 # ─────────────────────────────────────────────── eval
   eval_ci:
     cmd: >
       python -m model_lab.eval
-      --model   models/hf/candidates/${run_name}_merged
+      --model   models/hf/candidates/${family}/${run_name}_merged
       --dataset ${dataset.path}
       --batch   ${eval.batch_size}
       --max-len ${eval.max_length}
       --offload
     deps:
       - src/model_lab/eval.py
-      - models/hf/candidates/${run_name}_merged
+      - models/hf/candidates/${family}/${run_name}_merged
     metrics:
       - metrics/eval_ci.json:
           cache: false
 
 # ─────────────────────────────────────────────── docker
   docker:
-    cmd: scripts/build_image_ci.sh ${run_name}
+    cmd: scripts/build_image_ci.sh ${family} ${run_name} ${ci.quant_mode}
     deps:
       - scripts/build_image_ci.sh
       - Dockerfile.serve
-      - Modelfile
-      - models/gguf/${run_name}_full.gguf
-      - models/gguf/${run_name}_${ci.quant_mode}.gguf
+      - models/modelfiles/${family}/${run_name}.Modelfile
+      - models/gguf/${family}/${run_name}_full.gguf
+      - models/gguf/${family}/${run_name}_${ci.quant_mode}.gguf
     outs:
-      - .ci/image_${run_name}.txt
+      - .ci/image_${family}_${run_name}.txt

--- a/params.yaml
+++ b/params.yaml
@@ -1,6 +1,7 @@
 # ─── run identifier ───────────────────────────────────────────
+family:          qwen        # model family name
 run_name:        run-000
-output_root:     models/hf/wip        # wip folder base
+output_root:     models/hf/wip        # base folder for WIP runs
 
 # ─── base model ───────────────────────────────────────────────
 base_model:

--- a/src/model_lab/tools/generate_modelfile.py
+++ b/src/model_lab/tools/generate_modelfile.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+"""Generate an Ollama Modelfile pointing at a GGUF model."""
+import argparse
+from pathlib import Path
+
+TPL = """FROM {base}
+ADAPTER /model/model.gguf
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Create Modelfile for Ollama")
+    ap.add_argument("gguf", help="Path to gguf file (unused; for pipeline tracking)")
+    ap.add_argument("--base", default="llama2", help="Base model family")
+    ap.add_argument("--out", default="Modelfile", help="Output Modelfile path")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    template = Path('Modelfile.template')
+    text = template.read_text() if template.exists() else TPL
+    out.write_text(text.format(base=args.base))
+    print(f"\u2713 Modelfile written: {out}")
+
+if __name__ == "__main__":
+    main()

--- a/src/model_lab/train.py
+++ b/src/model_lab/train.py
@@ -3,7 +3,7 @@
 model_lab.train   (YAML-only configuration)
 
 • reads every knob from params.yaml
-• saves weights to  {output_root}/{timestamp}-{run_name}/
+• saves weights to  {output_root}/{family}/{timestamp}-{run_name}/
 • writes metrics/eval_local.json
 • defers tensor creation to batch time (low RAM)
 • offloads state dict to disk if needed (low GPU VRAM)
@@ -33,8 +33,9 @@ CFG["training"]["grad_accum"]   = int(CFG["training"]["grad_accum"])
 CFG["training"]["epochs"]       = int(CFG["training"]["epochs"])
 
 RUN   = CFG["run_name"]
+FAM   = CFG.get("family", "model")
 STAMP = dt.datetime.now().strftime("%Y-%m-%dT%H-%M")
-ROOT  = pathlib.Path(CFG["output_root"])
+ROOT  = pathlib.Path(CFG["output_root"]).joinpath(FAM)
 OUT   = (ROOT / f"{STAMP}-{RUN}").resolve()
 OFFLD = OUT / "offload"
 # create both directories


### PR DESCRIPTION
## Summary
- support `family` parameter in PowerShell scripts
- document the DVC workflow in README

## Testing
- `python -m py_compile src/model_lab/tools/generate_modelfile.py`


------
https://chatgpt.com/codex/tasks/task_e_6884f00b84088328b40e148b700c498c